### PR TITLE
Add slide template for bus work records

### DIFF
--- a/_posts/0000-01-02-base-datos-bus.md
+++ b/_posts/0000-01-02-base-datos-bus.md
@@ -1,0 +1,25 @@
+---
+layout: slide
+title: "Base de datos: trabajos de bus"
+---
+
+## Registro de trabajos de bus
+
+- Empresa: **Nobina / Pohjolan Liikenne**
+- Marca del bus: **BYD / Yutong**
+- Hora de inicio: `HH:MM`
+- Autobús número (foto): ____________________
+- Autobús placa (foto): ____________________
+- KM 7 (foto): ____________________
+
+### Fallos detectados
+1. Fallo + foto: ____________________
+2. Fallo + foto: ____________________
+3. Fallo + foto: ____________________
+4. Fallo + foto: ____________________
+5. Fallo + foto: ____________________
+6. Fallo + foto: ____________________
+7. Fallo + foto: ____________________
+8. Fallo + foto: ____________________
+
+- Hora de fin: `HH:MM`


### PR DESCRIPTION
### Motivation
- Provide a Spanish slide template to record bus work entries (operator/brand, start/end times, bus number and plate photos, KM-7 photo, and up to 8 fault+photo entries) for Nobina / Pohjolan Liikenne fleets.

### Description
- Add `_posts/0000-01-02-base-datos-bus.md`, a new slideshow post containing the Spanish form-style fields and headings for capturing bus job data and faults.

### Testing
- Ran `git diff --check`, which passed; attempted to run the slideshow with `script/server`, which failed because `jekyll` is not installed; attempted a Playwright screenshot of `http://127.0.0.1:4000`, which failed because the local server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b589163e7c832f91019802f1248d76)